### PR TITLE
OAuth Strategy 등록 절차 간소화

### DIFF
--- a/Server/lib/Web/routes/login.js
+++ b/Server/lib/Web/routes/login.js
@@ -16,13 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/**
- * 볕뉘 수정사항:
- * 로그인을 Passport 로 수행하기 위한 파일 생성
- * 쪼리핑님 요청에 따라 유동적으로 로그인 전략 생성
- */
-
- 
 const MainDB	 = require("../db");
 const JLog	 = require("../../sub/jjlog");
 // const Ajae	 = require("../../sub/ajaejs").checkAjae;
@@ -30,6 +23,7 @@ const passport = require('passport');
 const glob = require('glob-promise');
 const GLOBAL	 = require("../../sub/global.json");
 const config = require('../../sub/auth.json');
+const path = require('path')
 
 function process(req, accessToken, MainDB, $p, done) {
     $p.token = accessToken;
@@ -46,9 +40,9 @@ function process(req, accessToken, MainDB, $p, done) {
     MainDB.users.findOne([ '_id', $p.id ]).on(function($body){
         req.session.profile = $p;
         MainDB.users.update([ '_id', $p.id ]).set([ 'lastLogin', now ]).on();
-
-        done(null, $p);
     });
+
+    done(null, $p);
 }
 
 exports.run = (Server, page) => {
@@ -62,61 +56,54 @@ exports.run = (Server, page) => {
     });
 
     const strategyList = {};
+    
+	for (let i in config) {
+		let auth = require(path.resolve('..', 'auth', 'auth_' + i + '.json'))
+		Server.get('/login/' + auth.config.vendor, passport.authenticate(auth.config.vendor))
+		Server.get('/login/' + auth.config.vendor + '/callback', passport.authenticate(auth.config.vendor, {
+			successRedirect: '/',
+			failureRedirect: '/loginfail'
+		}))
+		passport.use(new auth.config.strategy(auth.strategyConfig, auth.strategy(process, MainDB /*, Ajae */)));
+		strategyList[auth.config.vendor] = {
+			vendor: auth.config.vendor,
+			displayName: auth.config.displayName,
+			color: auth.config.color,
+			fontColor: auth.config.fontColor
+		};
+	}
+	
+	Server.get("/login", function(req, res){
+		if(global.isPublic){
+			page(req, res, "login", { '_id': req.session.id, 'text': req.query.desc, 'loginList': strategyList});
+		}else{
+			let now = Date.now();
+			let id = req.query.id || "ADMIN";
+			let lp = {
+				id: id,
+				title: "LOCAL #" + id,
+				birth: [ 4, 16, 0 ],
+				_age: { min: 20, max: undefined }
+			};
+			MainDB.session.upsert([ '_id', req.session.id ]).set([ 'profile', JSON.stringify(lp) ], [ 'createdAt', now ]).on(function($res){
+				MainDB.users.update([ '_id', id ]).set([ 'lastLogin', now ]).on();
+				req.session.admin = true;
+				req.session.profile = lp;
+				res.redirect("/");
+			});
+		}
+	});
 
-    glob(__dirname + '/../auth/auth_*.js')
-    .then((items) => {
-        for (let i in items) {
-            let auth = require(items[i])
-            Server.get('/login/' + auth.config.vendor, passport.authenticate(auth.config.vendor))
-            Server.get('/login/' + auth.config.vendor + '/callback', passport.authenticate(auth.config.vendor, {
-                successRedirect: '/',
-                failureRedirect: '/loginfail'
-            }))
-            passport.use(new auth.config.strategy(auth.strategyConfig, auth.strategy(process, MainDB /*, Ajae */)));
-            strategyList[auth.config.vendor] = {
-                vendor: auth.config.vendor,
-                displayName: auth.config.displayName,
-                color: auth.config.color,
-                fontColor: auth.config.fontColor
-            };
-        }
-    })
-    .catch((e) => {
-        console.error(e)
-    })
-    .then(() => {
-        Server.get("/login", function(req, res){
-            if(global.isPublic){
-                page(req, res, "login", { '_id': req.session.id, 'text': req.query.desc, 'loginList': strategyList});
-            }else{
-                let now = Date.now();
-                let id = req.query.id || "ADMIN";
-                let lp = {
-                    id: id,
-                    title: "LOCAL #" + id,
-                    birth: [ 4, 16, 0 ],
-                    _age: { min: 20, max: undefined }
-                };
-                MainDB.session.upsert([ '_id', req.session.id ]).set([ 'profile', JSON.stringify(lp) ], [ 'createdAt', now ]).on(function($res){
-                    MainDB.users.update([ '_id', id ]).set([ 'lastLogin', now ]).on();
-                    req.session.admin = true;
-                    req.session.profile = lp;
-                    res.redirect("/");
-                });
-            }
-        });
+	Server.get("/logout", (req, res) => {
+		if(!req.session.profile){
+			return res.redirect("/");
+		} else {
+			req.session.destroy();
+			res.redirect('/');
+		}
+	});
 
-        Server.get("/logout", (req, res) => {
-            if(!req.session.profile){
-                return res.redirect("/");
-            } else {
-                req.session.destroy();
-                res.redirect('/');
-            }
-        });
-
-        Server.get("/loginfail", (req, res) => {
-            page(req, res, "loginfail");
-        });
-    });  
+	Server.get("/loginfail", (req, res) => {
+		page(req, res, "loginfail");
+	});
 }

--- a/Server/lib/Web/routes/login.js
+++ b/Server/lib/Web/routes/login.js
@@ -74,9 +74,9 @@ exports.run = (Server, page) => {
 			};
 
 			JLog.info(`OAuth Strategy ${i} loaded successfully.`)
-		} catch (e) {
+		} catch (error) {
 			JLog.error(`OAuth Strategy ${i} is not loaded`)
-			JLog.error(e)
+			JLog.error(error.message)
 		}
 	}
 	

--- a/Server/lib/Web/routes/login.js
+++ b/Server/lib/Web/routes/login.js
@@ -59,7 +59,7 @@ exports.run = (Server, page) => {
     
 	for (let i in config) {
 		try {
-			let auth = require(path.resolve(__dirname, '..', 'auth', 'auth_' + i + '.json'))
+			let auth = require(path.resolve(__dirname, '..', 'auth', 'auth_' + i + '.js'))
 			Server.get('/login/' + auth.config.vendor, passport.authenticate(auth.config.vendor))
 			Server.get('/login/' + auth.config.vendor + '/callback', passport.authenticate(auth.config.vendor, {
 				successRedirect: '/',


### PR DESCRIPTION
기존의 OAuth Strategy 등록은 glob로 Strategy 파일을 검색하여 등록함에 반해,
새로운 OAuth Strategy 등록은 auth.json 파일에 등록된 Strategy만 가져옵니다.

**즉 필요 없는 Strategy는 auth.json 에서 삭제하면 로드할 필요도 없으며, glob로 인한 불필요한 자원낭비가 없어집니다.**