### PR TITLE
도커 추가

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+/Server/lib/sub
+/docker-compose.yml
+/Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:10
+
+WORKDIR /app
+
+COPY ./Server/setup.js ./Server/
+COPY ./Server/package*.json ./Server/
+COPY ./Server/lib/package*.json ./Server/lib/
+
+RUN cd Server && node setup
+
+COPY . .
+
+RUN cd Server/lib && npx grunt default pack
+
+WORKDIR /kkutu

--- a/Server/lib/Game/cluster.js
+++ b/Server/lib/Game/cluster.js
@@ -41,7 +41,7 @@ if(Cluster.isMaster){
 	
 	for(i=0; i<CPU; i++){
 		chan = i + 1;
-		channels[chan] = Cluster.fork({ SERVER_NO_FORK: true, KKUTU_PORT: Const.MAIN_PORTS[SID] + 416 + i, CHANNEL: chan });
+		channels[chan] = Cluster.fork({ SERVER_NO_FORK: true, KKUTU_PORT: Const.MAIN_PORTS[SID] + 416 + (chan - 1), CHANNEL: chan });
 	}
 	Cluster.on('exit', function(w){
 		for(i in channels){

--- a/Server/lib/Game/master.js
+++ b/Server/lib/Game/master.js
@@ -285,7 +285,8 @@ exports.init = function(_SID, CHAN){
 				perMessageDeflate: false
 			});
 		}
-		Server.on('connection', function(socket){
+		Server.on('connection', function(socket, req){
+			socket.upgradeReq = req
 			var key = socket.upgradeReq.url.slice(1);
 			var $c;
 			
@@ -293,7 +294,7 @@ exports.init = function(_SID, CHAN){
 				JLog.warn("Error on #" + key + " on ws: " + err.toString());
 			});
 			// 웹 서버
-			if(socket.upgradeReq.headers.host.match(/^127\.0\.0\.2:/)){
+			if(socket.upgradeReq.headers.host.startsWith(GLOBAL.GAME_SERVER_HOST)){
 				if(WDIC[key]) WDIC[key].socket.close();
 				WDIC[key] = new KKuTu.WebServer(socket);
 				JLog.info(`New web server #${key}`);

--- a/Server/lib/Game/slave.js
+++ b/Server/lib/Game/slave.js
@@ -102,7 +102,8 @@ MainDB.ready = function(){
 	JLog.success("DB is ready.");
 	KKuTu.init(MainDB, DIC, ROOM, GUEST_PERMISSION);
 };
-Server.on('connection', function(socket){
+Server.on('connection', function(socket, req){
+	socket.upgradeReq = req;
 	var chunk = socket.upgradeReq.url.slice(1).split('&');
 	var key = chunk[0];
 	var reserve = RESERVED[key] || {}, room;

--- a/Server/lib/Web/db.js
+++ b/Server/lib/Web/db.js
@@ -41,7 +41,8 @@ const FAKE_REDIS = {
 Pub.ready = function(isPub){
 	var Redis	 = require("redis").createClient();
     var Pg = new PgPool({
-        user: GLOBAL.PG_USER,
+		user: GLOBAL.PG_USER,
+		host: GLOBAL.PG_HOST,
         password: GLOBAL.PG_PASSWORD,
         port: GLOBAL.PG_PORT,
         database: GLOBAL.PG_DATABASE

--- a/Server/lib/Web/db.js
+++ b/Server/lib/Web/db.js
@@ -41,8 +41,8 @@ const FAKE_REDIS = {
 Pub.ready = function(isPub){
 	var Redis	 = require("redis").createClient();
     var Pg = new PgPool({
-		user: GLOBAL.PG_USER,
-		host: GLOBAL.PG_HOST,
+	user: GLOBAL.PG_USER,
+	host: GLOBAL.PG_HOST,
         password: GLOBAL.PG_PASSWORD,
         port: GLOBAL.PG_PORT,
         database: GLOBAL.PG_DATABASE

--- a/Server/lib/Web/main.js
+++ b/Server/lib/Web/main.js
@@ -159,7 +159,7 @@ Const.MAIN_PORTS.forEach(function(v, i){
 	} else {
 		protocol = 'ws';
 	}
-	gameServers[i] = new GameClient(KEY, `${protocol}://127.0.0.2:${v}/${KEY}`);
+	gameServers[i] = new GameClient(KEY, `${protocol}://${GLOBAL.GAME_SERVER_HOST}:${v}/${KEY}`);
 });
 function GameClient(id, url){
 	var my = this;

--- a/Server/lib/sub/global.inc.json
+++ b/Server/lib/sub/global.inc.json
@@ -1,10 +1,10 @@
 {
 	"ADMIN": [ "Input admin id here" ],
 	"MAIN_PORTS": [ 8080 ],
-	"GAME_SERVER_HOST": "game",
+	"GAME_SERVER_HOST": "127.0.0.2",
 	"KKUTUHOT_PATH": "/kkutu/data/kkutuhot.json",
 	"PASS":"Your password for management Here",
-	"PG_HOST": "db",
+	"PG_HOST": "127.0.0.1",
 	"PG_USER": "postgres",
 	"PG_PASSWORD": "Your PostgreSQL Password Here",
 	"PG_PORT": 5432,

--- a/Server/lib/sub/global.inc.json
+++ b/Server/lib/sub/global.inc.json
@@ -1,8 +1,10 @@
 {
 	"ADMIN": [ "Input admin id here" ],
 	"MAIN_PORTS": [ 8080 ],
+	"GAME_SERVER_HOST": "game",
 	"KKUTUHOT_PATH": "/kkutu/data/kkutuhot.json",
 	"PASS":"Your password for management Here",
+	"PG_HOST": "db",
 	"PG_USER": "postgres",
 	"PG_PASSWORD": "Your PostgreSQL Password Here",
 	"PG_PORT": 5432,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+version: "3"
+
+services:
+  game:
+    build: .
+    volumes:
+    - ./Server/lib/sub:/app/Server/lib/sub
+    restart: always
+    depends_on:
+    - db
+    command: ["node", "/app/Server/lib/Game/cluster.js", "0", "1"]
+    ports:
+    - 8496:8496
+    - 8080:8080
+  web:
+    build: .
+    volumes:
+    - ./Server/lib/sub:/app/Server/lib/sub
+    restart: always
+    command: ["node", "/app/Server/lib/Web/cluster.js", "1"]
+    depends_on:
+    - db
+    - game
+    ports:
+    - 9000:80
+  db:
+    build:
+      context: .
+      dockerfile: ./psql.Dockerfile
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: main
+    restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     build: .
     volumes:
     - ./Server/lib/sub:/app/Server/lib/sub
+    - kkutu_data:/kkutu
     restart: always
     command: ["node", "/app/Server/lib/Web/cluster.js", "1"]
     depends_on:
@@ -31,3 +32,9 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: main
     restart: always
+    volumes:
+    - db_data:/var/lib/postgresql/data
+
+volumes:
+  kkutu_data:
+  db_data:

--- a/psql.Dockerfile
+++ b/psql.Dockerfile
@@ -1,0 +1,3 @@
+FROM postgres
+
+COPY db.sql /docker-entrypoint-initdb.d/10-init.sql


### PR DESCRIPTION
끄투를 도커에 넣었습니다.

비전은 docker-compose와 docker를 깔고 docker-compose up을 실행시키면 바로 온전한 끄투가 실행되는 것입니다. 이를 위해 서버가 실행하면서 global.json이나 auth.json이 없으면 .inc.json에서 복붙하고 oauth말고 아이디-패스워드 형식의 인증을 세팅하면 좋을 것 같습니다.

하위 호환을 위해 global.inc.json을 도커에 맞게 편집하지 않았습니다.
```
GAME_SERVER_HOST": "game"
"PG_HOST": "db"
"PG_PASSWORD": "postgres"
```
요렇게 수정해주시고 docker-compose up 하시면 작동하는 모습을 볼 수 있을 것.

주요 설정 파일(/Server/lib/sub)외에 놓치고 컨테이너에 마운트 하지 않은 설정 파일이 몇개 있는 것 같습니다. 참고하시길.
