### PR TITLE
Node.js v14 Compatible.

### DIFF
--- a/Server/lib/package-lock.json
+++ b/Server/lib/package-lock.json
@@ -1444,70 +1444,62 @@
       "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10="
     },
     "pg": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-6.4.2.tgz",
-      "integrity": "sha1-w2QBEGDqx6UHoq4GPrhX7OkQ4n8=",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.5.1.tgz",
+      "integrity": "sha512-9wm3yX9lCfjvA98ybCyw2pADUivyNWT/yIP4ZcDVpMN0og70BUWYEGXPCTAQdGTAqnytfRADb7NERrY1qxhIqw==",
       "requires": {
-        "buffer-writer": "1.0.1",
-        "js-string-escape": "1.0.1",
-        "packet-reader": "0.3.1",
-        "pg-connection-string": "0.1.3",
-        "pg-pool": "1.*",
-        "pg-types": "1.*",
-        "pgpass": "1.*",
-        "semver": "4.3.2"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
-          "integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c="
-        }
+        "buffer-writer": "2.0.0",
+        "packet-reader": "1.0.0",
+        "pg-connection-string": "^2.4.0",
+        "pg-pool": "^3.2.2",
+        "pg-protocol": "^1.4.0",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x"
       }
     },
     "pg-connection-string": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
-      "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.4.0.tgz",
+      "integrity": "sha512-3iBXuv7XKvxeMrIgym7njT+HlZkwZqqGX4Bu9cci8xHZNT+Um1gWKqCsAzcC0d95rcKMU5WBg6YRUcHyV0HZKQ=="
     },
     "pg-escape": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/pg-escape/-/pg-escape-0.2.0.tgz",
       "integrity": "sha1-ZVlMFpFlm0q24Mu/nVB0S+R0mY4="
     },
+    "pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
+    },
     "pg-pool": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-1.8.0.tgz",
-      "integrity": "sha1-9+xzgkw3oD8Hb1G/33DjQBR8Tzc=",
-      "requires": {
-        "generic-pool": "2.4.3",
-        "object-assign": "4.1.0"
-      },
-      "dependencies": {
-        "object-assign": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-          "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A="
-        }
-      }
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.2.2.tgz",
+      "integrity": "sha512-ORJoFxAlmmros8igi608iVEbQNNZlp89diFVx6yV5v+ehmpMY9sK6QgpmgoXbmkNaBAx8cOOZh9g80kJv1ooyA=="
+    },
+    "pg-protocol": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.4.0.tgz",
+      "integrity": "sha512-El+aXWcwG/8wuFICMQjM5ZSAm6OWiJicFdNYo+VY3QP+8vI4SvLIWVe51PppTzMhikUJR+PsyIFKqfdXPz/yxA=="
     },
     "pg-types": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.12.1.tgz",
-      "integrity": "sha1-1kCH45A7WP+q0nnnWVxSIIoUw9I=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
       "requires": {
-        "postgres-array": "~1.0.0",
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
         "postgres-bytea": "~1.0.0",
-        "postgres-date": "~1.0.0",
+        "postgres-date": "~1.0.4",
         "postgres-interval": "^1.1.0"
       }
     },
     "pgpass": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.2.tgz",
-      "integrity": "sha1-Knu0G2BltnkH6R2hsHwYR8h3swY=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.4.tgz",
+      "integrity": "sha512-YmuA56alyBq7M59vxVBfPJrGSozru8QAdoNlWuW3cz8l+UX3cWge0vTvjKhsSHSJpo3Bom8/Mm6hf0TR5GY0+w==",
       "requires": {
-        "split": "^1.0.0"
+        "split2": "^3.1.1"
       }
     },
     "pify": {

--- a/Server/lib/package.json
+++ b/Server/lib/package.json
@@ -33,7 +33,7 @@
 	"passport-line": "0.0.4",
 	"passport-instagram": "^1.0.0",
 	"passport-spotify": "^1.1.0",
-    "pg": "^6.1.2",
+    "pg": "^8.5.1",
     "pg-escape": "^0.2.0",
     "pug": "^2.0.4",
     "ws": "^3.3.1"


### PR DESCRIPTION
**[수정] 기존 끄투 코드가 최신버전의 pg 모듈과 맞지 않는 것 같습니다.**

```
Game server #1 has an error: Error: connect ECONNREFUSED ip:port
```
이 문제에 대한 해결 방법입니다.

```
DB is ready.
```
DB와 연결하지 못하는 현상에 대한 이슈가 상당히 많았었는데

모두 최신버전의 Node.js와 구버전의 pg 모듈을 같이 사용했기 때문이었습니다.

PostgreSQL 버전과도 연관이 있는지는 밝혀진 것이 없습니다.
(테스트 환경: Node.js v14.15.5, PostgreSQL 11.0, pg 8.5.1)

~~pg 모듈을 최신버전으로 업데이트하면 Node.js 14 버전에서도 문제 없이 동작합니다.~~

~~하지만 Node.js 12 버전이 최신버전의 pg 모듈과 아직 정상 작동하는지 알 수 없습니다.~~

**기존 끄투 코드가 최신버전의 pg 모듈과 맞지 않는 것 같습니다.
[node-postgres#1872](https://github.com/brianc/node-postgres/issues/1872) 와 동일한 문제가 발생합니다.**

관련: [node-postgres#2170](https://github.com/brianc/node-postgres/issues/2170) [node-postgres#717](https://github.com/vitaly-t/pg-promise/issues/717)