### PR TITLE
방번호가 틀리는 등의 상황에서 BGM이 꺼지지 않게 수정.

### DIFF
--- a/Server/lib/Web/lib/kkutu/body.js
+++ b/Server/lib/Web/lib/kkutu/body.js
@@ -470,7 +470,6 @@ function onMessage(data){
 			}else if(data.code == 416){
 				// 게임 중
 				if(confirm(L['error_'+data.code])){
-					stopBGM();
 					$data._spectate = true;
 					$data._gaming = true;
 					send('enter', { id: data.target, password: $data._pw, spectate: true }, true);


### PR DESCRIPTION
body.js만 수정하시면 됩니다.
못찾으시는분들을 위해서 남긴 PR입니다.
해당 PR은 한줄로 매우 짧습니다.
해당 PR은 선택형 PR로 적용하지 않으셔도 버그까진 아닌것같습니다.( BGM 꺼짐)
해당 PR을 적용하시면 비밀번호가 틀려도 BGM이 이어나가지게됩니다.